### PR TITLE
Fixed a few missing arguments from the Codex

### DIFF
--- a/api-mockup/firework.lua
+++ b/api-mockup/firework.lua
@@ -31,7 +31,7 @@ function Firework()
 
     --- Returns the delay before the launched Fireworks explodes
     ---@return number
-    function self.getExplosionDelay(delay) end
+    function self.getExplosionDelay() end
 
     --- Set the speed at which the firework will be launched (impacts its altitude, depending on the local gravity).
     ---@param speed number The launch speed in m/s (maximum 200m/s)

--- a/api-mockup/radar.lua
+++ b/api-mockup/radar.lua
@@ -45,28 +45,34 @@ function Radar()
     function self.getTargetId() end
 
     --- Returns the distance to the given construct
+    ---@param id integer The ID of the construct
     ---@return number
     function self.getConstructDistance(id) end
 
     --- Returns 1 if the given construct is identified
+    ---@param id integer The ID of the construct
     ---@return integer
     function self.isConstructIdentified(id) end
 
     --- Returns 1 if the given construct was abandoned
+    ---@param id integer The ID of the construct
     ---@return integer
     function self.isConstructAbandoned(id) end
 
     --- Returns the core size of the given construct
+    ---@param id integer The ID of the construct
     ---@return string size The core size name; can be 'XS', 'S', 'M', 'L', 'XL'
     function self.getConstructCoreSize(id) end
 
     --- Returns the threat rate your construct is for the given construct
+    ---@param id integer The ID of the construct
     ---@return integer threat The threat rate index (None = 1, Identified = 2, Threatened and identified = 3, Threatened = 4, Attacked = 5), can be -1 if the radar is not operational
     function self.getThreatRateTo(id) end
     ---@deprecated Radar.getThreatTo(id) is deprecated, use Radar.getThreatRateTo(id) instead.
     function self.getThreatTo() error("Radar.getThreatTo(id) is deprecated, use Radar.getThreatRateTo(id) instead.") end
 
     --- Returns the threat rate the given construct is for your construct
+    ---@param id integer The ID of the construct
     ---@return string threat The threat rate index (None = 1, Identified = 2, Threatened and identified = 3, Threatened = 4, Attacked = 5), can be -1 if the radar is not operational
     function self.getThreatRateFrom(id) end
     ---@deprecated Radar.getThreatFrom(id) is deprecated, use Radar.getThreatRateFrom(id) instead.


### PR DESCRIPTION
On the Firework class, removed wrong argument `delay` from `getExplosionDelay`

On the Radar class, added the missing `@param` LuaDoc for the `id` arguments on the functions `getConstructDistance`, `isConstructIdentified`, `isConstructAbandoned`, `getConstructCoreSize`, `getThreatRateTo` and `getThreatRateFrom`